### PR TITLE
feat: Prepare package for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+# Exclude directories
+examples/
+
+# Exclude test files
+*.test.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -2676,18 +2676,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -5318,15 +5306,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "1.0.0",
   "description": "A simple, lightweight dependency injection container for JavaScript and TypeScript.",
   "type": "module",
-  "main": "dist/light-di.ts",
+  "main": "dist/light-di.js",
   "types": "dist/light-di.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/user/repo.git"
+  },
   "scripts": {
-    "build": "babel src --out-dir dist --extensions \".js\" && tsc",
+    "build": "babel src --out-dir dist --extensions \".js\" --ignore \"src/**/*.test.js\" && tsc",
     "prepublishOnly": "npm run build",
     "test": "vitest --coverage",
     "example": "node main.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "allowJs": true,
+    "emitDeclarationOnly": true
   },
-  "include": ["**/*.ts", "**/*.d.ts"],
-  "exclude": ["node_modules", "dist", "examples"]
+  "include": ["src/**/*.js"],
+  "exclude": ["node_modules", "dist", "examples", "src/**/*.test.js"]
 }


### PR DESCRIPTION
This commit prepares the package for publishing to npm by making the following changes:

- Updated `package.json` to point the `main` entry to the compiled JavaScript file.
- Added a `repository` field to `package.json`.
- Modified the `build` script to exclude test files from the output.
- Created a `.npmignore` file to exclude the `examples` directory and test files from the published package.
- Updated `tsconfig.json` to correctly generate TypeScript declaration files for the JavaScript source files.